### PR TITLE
refactor(*): use eslint-config-moving-meadow

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,8 +5,7 @@ checks:
       threshold: 40
 plugins:
   eslint:
-    enabled: true
-    channel: "eslint-4"
+    enabled: false
 exclude_patterns:
   - ".github/"
   - "config/"

--- a/bin/upem.js
+++ b/bin/upem.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 const path = require("path");
 const libNpmConfig = require("libnpmconfig");
-const up = require("../src");
 const getStdin = require("get-stdin");
+const up = require("../src");
 
 const PACKAGE_FILE_NAME = path.join(process.cwd(), "package.json");
 

--- a/package.json
+++ b/package.json
@@ -33,15 +33,16 @@
     "url": "https://github.com/sverweij/upem/issues"
   },
   "devDependencies": {
-    "dependency-cruiser": "8.0.0",
+    "dependency-cruiser": "8.0.2",
     "eslint": "6.8.0",
-    "eslint-config-prettier": "6.10.0",
-    "eslint-config-standard": "14.1.0",
+    "eslint-config-moving-meadow": "1.2.0",
+    "eslint-config-prettier": "6.10.1",
+    "eslint-plugin-budapestian": "1.1.1",
     "eslint-plugin-import": "2.20.1",
+    "eslint-plugin-jest": "23.8.2",
     "eslint-plugin-node": "11.0.0",
-    "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-security": "1.4.0",
-    "eslint-plugin-standard": "4.0.1",
+    "eslint-plugin-unicorn": "15.0.1",
     "husky": "3.1.0",
     "jest": "24.9.0",
     "lint-staged": "9.5.0",
@@ -77,45 +78,52 @@
   "upem": {
     "donotup": [
       {
+        "package": "eslint-plugin-unicorn",
+        "because": "eslint-plugin-unicorn 16 and up don't support node 8 anymore while up'em still does."
+      },
+      {
         "package": "husky",
         "because": "husky 4 doesn't support node 8 anymore while up'em still does."
+      },
+      {
+        "package": "jest",
+        "because": "due to bug https://github.com/facebook/jest/issues/9450 - jest inadvertently breaks on node 8"
       },
       {
         "package": "lint-staged",
         "because": "lint-staged 10 doesn't support node 8 anymore while up'em still does."
       },
       {
-        "package": "jest",
-        "because": "due to bug https://github.com/facebook/jest/issues/9450 - jest inadvertently breaks on node 8"
+        "package": "prettier",
+        "because": "prettier 2 doesn't support node 8 anymore while up'em still does."
       }
     ]
   },
   "eslintConfig": {
     "extends": [
-      "standard",
-      "prettier"
-    ],
-    "plugins": [
-      "security"
+      "moving-meadow"
     ],
     "rules": {
       "complexity": [
         "warn",
         4
       ],
-      "security/detect-unsafe-regex": "error",
-      "security/detect-buffer-noassert": "error",
-      "security/detect-child-process": "error",
-      "security/detect-disable-mustache-escape": "error",
-      "security/detect-eval-with-expression": "error",
-      "security/detect-no-csrf-before-method-override": "error",
       "security/detect-non-literal-fs-filename": "off",
-      "security/detect-non-literal-regexp": "error",
-      "security/detect-non-literal-require": "error",
-      "security/detect-object-injection": "off",
-      "security/detect-possible-timing-attacks": "error",
-      "security/detect-pseudoRandomBytes": "error"
-    }
+      "security/detect-object-injection": "off"
+    },
+    "overrides": [
+      {
+        "files": [
+          "test/**/*.js"
+        ],
+        "env": {
+          "jest": true
+        },
+        "rules": {
+          "global-require": "off"
+        }
+      }
+    ]
   },
   "jest": {
     "clearMocks": true,
@@ -128,7 +136,7 @@
     "testEnvironment": "node"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=8.3"
   },
   "husky": {
     "hooks": {

--- a/src/core.js
+++ b/src/core.js
@@ -8,7 +8,7 @@ function updateDeps(pDependencyObject, pOutdatedPackagesObject, pOptions = {}) {
     ...pDependencyObject,
     ...Object.keys(pDependencyObject)
       .filter(pDep =>
-        Object.keys(pOutdatedPackagesObject).some(pPkg => pPkg === pDep)
+        Object.keys(pOutdatedPackagesObject).some(pPackage => pPackage === pDep)
       )
       .reduce((pAll, pThis) => {
         pAll[pThis] = `${lSavePrefix}${pOutdatedPackagesObject[pThis].latest}`;
@@ -26,12 +26,12 @@ function getDoNotUpArray(pPackageObject) {
 }
 
 function filterOutdatedPackages(pOutdatedObject, pPackageObject) {
-  const lRetval = { ...pOutdatedObject };
+  const lReturnValue = { ...pOutdatedObject };
 
-  Object.keys(lRetval)
+  Object.keys(lReturnValue)
     .filter(pKey => getDoNotUpArray(pPackageObject).includes(pKey))
-    .forEach(pKey => delete lRetval[pKey]);
-  return lRetval;
+    .forEach(pKey => Reflect.deleteProperty(lReturnValue, pKey));
+  return lReturnValue;
 }
 
 /**
@@ -53,7 +53,7 @@ function updateAllDeps(pPackageObject, pOutdatedPackages = {}, pOptions = {}) {
   return {
     ...pPackageObject,
     ...Object.keys(pPackageObject)
-      .filter(pPkgKey => pPkgKey.includes("ependencies"))
+      .filter(pPackageKey => pPackageKey.includes("ependencies"))
       .reduce((pAll, pDepKey) => {
         pAll[pDepKey] = updateDeps(
           pPackageObject[pDepKey],

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 const fs = require("fs");
 const core = require("./core");
 
+const INDENT = 2;
+
 function determineOutdated(pOutdatedObject, pPackageObject) {
   pOutdatedObject =
     pOutdatedObject.length <= 0 ? {} : JSON.parse(pOutdatedObject);
@@ -41,6 +43,7 @@ module.exports = (
     const lPackageObject = JSON.parse(lPackageFile);
 
     const lOutdatedResult = determineOutdated(pOutdatedObject, lPackageObject);
+
     if (!lOutdatedResult.outdatedObject) {
       return lOutdatedResult;
     }
@@ -55,7 +58,7 @@ module.exports = (
             pOptions
           ),
           null,
-          2
+          INDENT
         )
       );
       return {
@@ -64,16 +67,16 @@ module.exports = (
           lOutdatedResult.outdatedObject
         ).join(", ")}\n\n`
       };
-    } catch (pPackageWriteError) {
+    } catch (pError) {
       return {
         OK: false,
-        message: `  Up'em encountered a hitch when updating package.json:\n${pPackageWriteError}\n\n`
+        message: `  Up'em encountered a hitch when updating package.json:\n${pError}\n\n`
       };
     }
-  } catch (pPackageReadError) {
+  } catch (pError) {
     return {
       OK: false,
-      message: `  Up'em encountered a hitch:\n${pPackageReadError}\n\n`
+      message: `  Up'em encountered a hitch:\n${pError}\n\n`
     };
   }
 };

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -1,4 +1,5 @@
 const up = require("../src/core");
+
 const DEPS_FIXTURE = {
   "not-outdated": "1.0.0",
   "outdated-one": "2.0.0",
@@ -33,57 +34,55 @@ const OUTDATED_FIXTURE = {
     location: "node_modules/outdated-possibly-pinned"
   }
 };
+
 describe("#updateDeps", () => {
-  test("empty deps, no outdated yield input", () => {
-    expect(up.updateDeps({}, [])).toEqual({});
+  it("empty deps, no outdated yield input", () => {
+    expect(up.updateDeps({}, [])).toStrictEqual({});
   });
-  test("deps, no outdated yield input", () => {
-    expect(up.updateDeps(DEPS_FIXTURE, {})).toEqual(DEPS_FIXTURE);
+  it("deps, no outdated yield input", () => {
+    expect(up.updateDeps(DEPS_FIXTURE, {})).toStrictEqual(DEPS_FIXTURE);
   });
-  test("deps, no outdated yield input", () => {
-    expect(up.updateDeps(DEPS_FIXTURE, {})).toEqual(DEPS_FIXTURE);
-  });
-  test("deps, outdated yields updated deps, prefixed with carets", () => {
-    expect(up.updateDeps(DEPS_FIXTURE, OUTDATED_FIXTURE)).toEqual(
+  it("deps, outdated yields updated deps, prefixed with carets", () => {
+    expect(up.updateDeps(DEPS_FIXTURE, OUTDATED_FIXTURE)).toStrictEqual(
       DEPS_UPDATED_CARET_FIXTURE
     );
   });
-  test("deps, outdated with saveExact yields updated deps, pinned", () => {
+  it("deps, outdated with saveExact yields updated deps, pinned", () => {
     expect(
       up.updateDeps(DEPS_FIXTURE, OUTDATED_FIXTURE, { saveExact: true })
-    ).toEqual(DEPS_UPDATED_PINNED_FIXTURE);
+    ).toStrictEqual(DEPS_UPDATED_PINNED_FIXTURE);
   });
-  test("deps, outdated with saveExact yields updated deps, pinned even when savePrefix ^ is provided", () => {
+  it("deps, outdated with saveExact yields updated deps, pinned even when savePrefix ^ is provided", () => {
     expect(
       up.updateDeps(DEPS_FIXTURE, OUTDATED_FIXTURE, {
         saveExact: true,
         savePrefix: "^"
       })
-    ).toEqual(DEPS_UPDATED_PINNED_FIXTURE);
+    ).toStrictEqual(DEPS_UPDATED_PINNED_FIXTURE);
   });
-  test("deps, outdated with saveExact false yields updated deps, caret prefixed", () => {
+  it("deps, outdated with saveExact false yields updated deps, caret prefixed", () => {
     expect(
       up.updateDeps(DEPS_FIXTURE, OUTDATED_FIXTURE, { saveExact: false })
-    ).toEqual(DEPS_UPDATED_CARET_FIXTURE);
+    ).toStrictEqual(DEPS_UPDATED_CARET_FIXTURE);
   });
-  test("deps, outdated with savePrefix ~ yields updated deps, tilde prefixed", () => {
+  it("deps, outdated with savePrefix ~ yields updated deps, tilde prefixed", () => {
     expect(
       up.updateDeps(DEPS_FIXTURE, OUTDATED_FIXTURE, { savePrefix: "~" })
-    ).toEqual(DEPS_UPDATED_TILDE_FIXTURE);
+    ).toStrictEqual(DEPS_UPDATED_TILDE_FIXTURE);
   });
 });
 
 describe("#updateAllDeps", () => {
-  test("empty package.json, no outdated yield input", () => {
-    expect(up.updateAllDeps({}, {})).toEqual({});
-    expect(up.updateAllDeps({})).toEqual({});
+  it("empty package.json, no outdated yield input", () => {
+    expect(up.updateAllDeps({}, {})).toStrictEqual({});
+    expect(up.updateAllDeps({})).toStrictEqual({});
   });
 
-  test("empty package.json, several outdated yield input", () => {
-    expect(up.updateAllDeps({}, ["aap", "noot", "mies"])).toEqual({});
+  it("empty package.json, several outdated yield input", () => {
+    expect(up.updateAllDeps({}, ["aap", "noot", "mies"])).toStrictEqual({});
   });
 
-  test("real package.json, several outdated yield updated output", () => {
+  it("real package.json, several outdated yield updated output", () => {
     expect(
       up.updateAllDeps(
         require("./package-in.json"),
@@ -92,64 +91,63 @@ describe("#updateAllDeps", () => {
           saveExact: true
         }
       )
-    ).toEqual(require("./package-out.json"));
+    ).toStrictEqual(require("./package-out.json"));
   });
 });
 
 describe("#filterOutdatedPackages", () => {
-  test("empty outdated + empty package => empty outdated", () => {
-    expect(up.filterOutdatedPackages({}, {})).toEqual({});
+  it("empty outdated + empty package => empty outdated", () => {
+    expect(up.filterOutdatedPackages({}, {})).toStrictEqual({});
   });
 
-  test("empty outdated + package => empty outdated", () => {
-    expect(up.filterOutdatedPackages({}, require("./package-in.json"))).toEqual(
-      {}
-    );
+  it("empty outdated + package => empty outdated", () => {
+    expect(
+      up.filterOutdatedPackages({}, require("./package-in.json"))
+    ).toStrictEqual({});
   });
 
-  test("outdated + package with upem.donotup => outdated without the upem.donotup", () => {
+  it("outdated + package with upem.donotup => outdated without the upem.donotup", () => {
     expect(
       up.filterOutdatedPackages(
         require("./outdated.json"),
         require("./package-in.json")
       )
-    ).toEqual(require("./outdated-filtered.json"));
+    ).toStrictEqual(require("./outdated-filtered.json"));
   });
 
-  test("outdated + package with upem.donotup as a string => outdated without the upem.donotup", () => {
+  it("outdated + package with upem.donotup as a string => outdated without the upem.donotup", () => {
     expect(
       up.filterOutdatedPackages(
         require("./outdated.json"),
         require("./package-with-donotup-string.json")
       )
-    ).toEqual(require("./outdated-filtered.json"));
+    ).toStrictEqual(require("./outdated-filtered.json"));
   });
 
-  test("outdated + package with upem.donotup objects => outdated without the upem.donotup", () => {
+  it("outdated + package with upem.donotup objects => outdated without the upem.donotup", () => {
     expect(
       up.filterOutdatedPackages(
         require("./outdated.json"),
         require("./package-in-with-donotup-object.json")
       )
-    ).toEqual(require("./outdated-filtered.json"));
+    ).toStrictEqual(require("./outdated-filtered.json"));
   });
 
-  test("outdated + package with upem.donotup => outdated without the upem.donotup", () => {
+  it("outdated + package without upem.donotup => outdated without the upem.donotup", () => {
     expect(
       up.filterOutdatedPackages(
         require("./outdated.json"),
         require("./package-in-without-upem-donotup.json")
       )
-    ).toEqual(require("./outdated.json"));
+    ).toStrictEqual(require("./outdated.json"));
   });
 
-  test("outdated + package with upem.donotup => outdated with erroneous upem.donotup", () => {
+  it("outdated + package with upem.donotup => outdated with erroneous upem.donotup", () => {
     expect(
       up.filterOutdatedPackages(
         require("./outdated.json"),
         require("./package-in-with-erroneous-upem-donotup.json")
       )
-    ).toEqual(require("./outdated.json"));
+    ).toStrictEqual(require("./outdated.json"));
   });
 });
-/* global describe, test, expect */

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -3,29 +3,32 @@ const path = require("path");
 const up = require("../src");
 
 describe("#upppity", () => {
-  test("non-existing package.json errors", () => {
+  it("non-existing package.json errors", () => {
     const lResult = up("thisfiledoesnotexist", "");
-    expect(lResult.OK).toEqual(false);
+
+    expect(lResult.OK).toStrictEqual(false);
     expect(lResult.message).toContain("Up'em encountered a hitch:");
   });
 
-  test('empty string dependency JSON yields "nothing to update"', () => {
+  it('empty string dependency JSON yields "nothing to update"', () => {
     const lResult = up(path.join(__dirname, "package-in.json"), "");
-    expect(lResult.OK).toEqual(true);
+
+    expect(lResult.OK).toStrictEqual(true);
     expect(lResult.message).toContain(
       "Up'em says: Everything seems to be up to date already."
     );
   });
 
-  test('{} dependency JSON yields "nothing to update"', () => {
+  it('{} dependency JSON yields "nothing to update"', () => {
     const lResult = up(path.join(__dirname, "package-in.json"), "{}");
-    expect(lResult.OK).toEqual(true);
+
+    expect(lResult.OK).toStrictEqual(true);
     expect(lResult.message).toContain(
       "Up'em says: Everything seems to be up to date already."
     );
   });
 
-  test("read only package.json yields a 'can't update", () => {
+  it("read only package.json yields a 'can't update", () => {
     const OUTDATED_JSON = `
     {
       "lodash.assign": {
@@ -40,15 +43,17 @@ describe("#upppity", () => {
       __dirname,
       "package-in-readonly.json"
     );
+
     fs.chmodSync(READONLY_INPUT_FILENAME, "400");
     const lResult = up(READONLY_INPUT_FILENAME, OUTDATED_JSON);
-    expect(lResult.OK).toEqual(false);
+
+    expect(lResult.OK).toStrictEqual(false);
     expect(lResult.message).toContain(
       "Up'em encountered a hitch when updating package.json:"
     );
   });
 
-  test("if upem.donotup encompasses the outdated object yields that in a message", () => {
+  it("if upem.donotup encompasses the outdated object yields that in a message", () => {
     const OUTDATED_JSON = `
     {
       "ts-jest": {
@@ -60,13 +65,14 @@ describe("#upppity", () => {
     }
     `;
     const lResult = up(path.join(__dirname, "package-in.json"), OUTDATED_JSON);
-    expect(lResult.OK).toEqual(true);
+
+    expect(lResult.OK).toStrictEqual(true);
     expect(lResult.message).toContain(
       "Up'em says: Everything not in 'upem.donotup' seems to be up to date already."
     );
   });
 
-  test("happy day: dependencies updated with stuff in an outdated.json", () => {
+  it("happy day: dependencies updated with stuff in an outdated.json", () => {
     const OUTDATED_JSON = fs.readFileSync(
       path.join(__dirname, "outdated.json")
     );
@@ -78,17 +84,15 @@ describe("#upppity", () => {
       saveExact: true
     });
 
-    expect(lResult.OK).toEqual(true);
+    expect(lResult.OK).toStrictEqual(true);
     expect(lResult.message).toContain(
       "Up'em just updated all outdated dependencies in package.json to latest"
     );
     expect(lResult.message).toContain(
       "@types/node, dependency-cruiser, jest, webpack"
     );
-    expect(JSON.parse(fs.readFileSync(OUTPUT_FILENAME))).toEqual(
+    expect(JSON.parse(fs.readFileSync(OUTPUT_FILENAME))).toStrictEqual(
       JSON.parse(fs.readFileSync(FIXTURE_FILENAME))
     );
   });
 });
-
-/* global describe, test, expect */


### PR DESCRIPTION
## Description, Motivation and Context

- One config to rule them all
- Disables eslint on codeclimate as (1) it doesn't add much value to do it there _and_ on the ci's (2) it errors a little too often (with plugins not working)

## How Has This Been Tested?

Green ci.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
