### PR TITLE
feature: do not up peerDependencies

### DIFF
--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -14,7 +14,6 @@ jobs:
         node-version:
           - 10.x
           - 12.x
-          - 13.x
           - 14.x
         platform:
           - ubuntu-latest
@@ -23,8 +22,6 @@ jobs:
           - node-version: 10.x
             platform: windows-latest
           - node-version: 12.x
-            platform: windows-latest
-          - node-version: 13.x
             platform: windows-latest
 
     runs-on: ${{matrix.platform}}

--- a/README.md
+++ b/README.md
@@ -99,6 +99,22 @@ save-prefix = '^'
 Whatever your preferences: commit a `.npmrc` at the root of all your repos so
 npm, yarn and upem behavior is the same accross all machines and collaborators.
 
+### Not updating peerDependencies
+
+As of version 5.0.0 _Up'em_ leaves peerDependencies alone. Typically you'll use
+ranges for peerDependencies (`>=3` or `>=1.0.0 <3.0.0`). Those have different
+requirements from your regular dependencies. They can either be more lenient,
+or more strict.
+
+An example where you might want to be more lenient is when in your devDependencies
+want to use latest TypeScript, but you still might want to support TypeScript 3
+and up. In that case you will want to keep the `"typescript": ">=3"` in your
+peer dependencies.
+
+An example where you might want to be more strict is setting an upper limit to
+your peer dependencies version e.g. because you don't support beyond that version
+or don't know whether you can (`"typescript": ">=3.0.0 <6.0.0"`).
+
 ## Why?
 
 I've been a happy user of [npm-check-updates](https://github.com/tjunnone/npm-check-updates)

--- a/bin/upem.js
+++ b/bin/upem.js
@@ -11,6 +11,7 @@ getStdin()
     const lResult = up(PACKAGE_FILE_NAME, pOutdatedObject, PACKAGE_FILE_NAME, {
       saveExact: libNpmConfig.read().get("save-exact") || false,
       savePrefix: libNpmConfig.read().get("save-prefix") || "^",
+      skipDependencyTypes: ["peerDependencies"],
     });
 
     if (lResult.OK) {

--- a/src/core.js
+++ b/src/core.js
@@ -55,7 +55,11 @@ function updateAllDeps(pPackageObject, pOutdatedPackages = {}, pOptions = {}) {
   return {
     ...pPackageObject,
     ...Object.keys(pPackageObject)
-      .filter((pPackageKey) => pPackageKey.includes("ependencies"))
+      .filter(
+        (pPackageKey) =>
+          pPackageKey.includes("ependencies") &&
+          !_get(pOptions, "skipDependencyTypes", []).includes(pPackageKey)
+      )
       .reduce((pAll, pDepKey) => {
         pAll[pDepKey] = updateDeps(
           pPackageObject[pDepKey],

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const up = require("../src");
 
-describe("#upppity", () => {
+describe("#upem", () => {
   it("non-existing package.json errors", () => {
     const lResult = up("thisfiledoesnotexist", "");
 
@@ -90,6 +90,125 @@ describe("#upppity", () => {
     );
     expect(lResult.message).toContain(
       "@types/node, dependency-cruiser, jest, webpack"
+    );
+    expect(JSON.parse(fs.readFileSync(OUTPUT_FILENAME))).toStrictEqual(
+      JSON.parse(fs.readFileSync(FIXTURE_FILENAME))
+    );
+  });
+
+  it("happy day: don't up peerDependencies when told not to", () => {
+    const OUTDATED = JSON.stringify({
+      "prod-dep": {
+        current: "1.2.3",
+        wanted: "1.2.3",
+        latest: "1.3.0",
+        location: "node_modules/prod-dep",
+      },
+      "prod-dep-two": {
+        current: "4.5.6",
+        wanted: "4.5.6",
+        latest: "5.0.0",
+        location: "node_modules/prod-dep-two",
+      },
+      "dev-dep": {
+        current: "1.2.3",
+        wanted: "1.2.3",
+        latest: "1.3.0",
+        location: "node_modules/dev-dep",
+      },
+      "dev-and-peer-dep": {
+        current: "4.5.6",
+        wanted: "4.5.6",
+        latest: "4.6.0",
+        location: "node_modules/dev-and-peer-dep",
+      },
+      "peer-only-dep": {
+        current: "4.8.1",
+        wanted: ">=4.8.1",
+        latest: "4.9.0",
+        location: "node_modules/peer-only-dep",
+      },
+    });
+    const INPUT_FILENAME = path.join(
+      __dirname,
+      "package-in-with-peer-deps.json"
+    );
+    const OUTPUT_FILENAME = path.join(__dirname, "tmp_package-out.json");
+    const FIXTURE_FILENAME = path.join(
+      __dirname,
+      "package-out-with-peer-deps-not-updated.json"
+    );
+
+    const lResult = up(INPUT_FILENAME, OUTDATED, OUTPUT_FILENAME, {
+      saveExact: true,
+      skipDependencyTypes: ["peerDependencies"],
+    });
+
+    expect(lResult.OK).toStrictEqual(true);
+    expect(lResult.message).toContain(
+      "Up'em just updated all outdated dependencies in package.json to latest"
+    );
+    expect(lResult.message).toContain(
+      "prod-dep, prod-dep-two, dev-dep, dev-and-peer-dep"
+    );
+    expect(JSON.parse(fs.readFileSync(OUTPUT_FILENAME))).toStrictEqual(
+      JSON.parse(fs.readFileSync(FIXTURE_FILENAME))
+    );
+  });
+
+  it("happy day: do up peerDependencies when not told not to", () => {
+    const OUTDATED = JSON.stringify({
+      "prod-dep": {
+        current: "1.2.3",
+        wanted: "1.2.3",
+        latest: "1.3.0",
+        location: "node_modules/prod-dep",
+      },
+      "prod-dep-two": {
+        current: "4.5.6",
+        wanted: "4.5.6",
+        latest: "5.0.0",
+        location: "node_modules/prod-dep-two",
+      },
+      "dev-dep": {
+        current: "1.2.3",
+        wanted: "1.2.3",
+        latest: "1.3.0",
+        location: "node_modules/dev-dep",
+      },
+      "dev-and-peer-dep": {
+        current: "4.5.6",
+        wanted: "4.5.6",
+        latest: "4.6.0",
+        location: "node_modules/dev-and-peer-dep",
+      },
+      "peer-only-dep": {
+        current: "4.8.1",
+        wanted: ">=4.8.1",
+        latest: "4.9.0",
+        location: "node_modules/peer-only-dep",
+      },
+    });
+    const INPUT_FILENAME = path.join(
+      __dirname,
+      "package-in-with-peer-deps.json"
+    );
+    const OUTPUT_FILENAME = path.join(__dirname, "tmp_package-out.json");
+    const FIXTURE_FILENAME = path.join(
+      __dirname,
+      "package-out-with-peer-deps-updated.json"
+    );
+
+    const lResult = up(INPUT_FILENAME, OUTDATED, OUTPUT_FILENAME, {
+      saveExact: true,
+    });
+
+    expect(lResult.OK).toStrictEqual(true);
+    expect(lResult.message).toContain(
+      "Up'em just updated all outdated dependencies in package.json to latest"
+    );
+    expect(lResult.message).toContain(
+      "prod-dep, prod-dep-two, dev-dep, dev-and-peer-dep, peer-only-dep"
     );
     expect(JSON.parse(fs.readFileSync(OUTPUT_FILENAME))).toStrictEqual(
       JSON.parse(fs.readFileSync(FIXTURE_FILENAME))

--- a/test/package-in-with-peer-deps.json
+++ b/test/package-in-with-peer-deps.json
@@ -1,0 +1,18 @@
+{
+  "name": "package-in-with-peer-deps",
+  "version": "2.1.0-beta-0",
+  "description": "Sequence chart rendering library",
+  "main": "dist/index.js",
+  "dependencies": {
+    "prod-dep": "1.2.3",
+    "prod-dep-two": "4.5.6"
+  },
+  "devDependencies": {
+    "dev-dep": "1.2.3",
+    "dev-and-peer-dep": "4.5.6"
+  },
+  "peerDependencies": {
+    "dev-and-peer-dep": ">=1",
+    "peer-only-dep": ">=4.8.1"
+  }
+}

--- a/test/package-out-with-peer-deps-not-updated.json
+++ b/test/package-out-with-peer-deps-not-updated.json
@@ -1,0 +1,18 @@
+{
+  "name": "package-in-with-peer-deps",
+  "version": "2.1.0-beta-0",
+  "description": "Sequence chart rendering library",
+  "main": "dist/index.js",
+  "dependencies": {
+    "prod-dep": "1.3.0",
+    "prod-dep-two": "5.0.0"
+  },
+  "devDependencies": {
+    "dev-dep": "1.3.0",
+    "dev-and-peer-dep": "4.6.0"
+  },
+  "peerDependencies": {
+    "dev-and-peer-dep": ">=1",
+    "peer-only-dep": ">=4.8.1"
+  }
+}

--- a/test/package-out-with-peer-deps-updated.json
+++ b/test/package-out-with-peer-deps-updated.json
@@ -1,0 +1,18 @@
+{
+  "name": "package-in-with-peer-deps",
+  "version": "2.1.0-beta-0",
+  "description": "Sequence chart rendering library",
+  "main": "dist/index.js",
+  "dependencies": {
+    "prod-dep": "1.3.0",
+    "prod-dep-two": "5.0.0"
+  },
+  "devDependencies": {
+    "dev-dep": "1.3.0",
+    "dev-and-peer-dep": "4.6.0"
+  },
+  "peerDependencies": {
+    "dev-and-peer-dep": "4.6.0",
+    "peer-only-dep": "4.9.0"
+  }
+}


### PR DESCRIPTION
## Description, Motivation and Context

Makes sure peerDependencies don't get updated. See addition to the README for motivation & context.

Later on we might introduce a cli option for this, but this covers my current needs.

## How Has This Been Tested?

- [x] additional automated tests
- [x] automated non-regression tests
- [x] green ci 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
