### PR TITLE
feature: adds ability to override saveExact=true for individual packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/sverweij/upem/issues"
   },
   "devDependencies": {
-    "dependency-cruiser": "10.0.4",
+    "dependency-cruiser": "^10.0.4",
     "eslint": "7.30.0",
     "eslint-config-moving-meadow": "2.0.9",
     "eslint-config-prettier": "8.3.0",
@@ -48,13 +48,13 @@
     "eslint-plugin-unicorn": "34.0.1",
     "husky": "4.3.8",
     "jest": "27.0.6",
-    "lint-staged": "11.0.0",
-    "npm-run-all": "4.1.5",
-    "prettier": "2.3.2"
+    "lint-staged": "^11.0.0",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^2.3.2"
   },
   "dependencies": {
-    "get-stdin": "9.0.0",
-    "libnpmconfig": "1.2.1",
+    "get-stdin": "^9.0.0",
+    "libnpmconfig": "^1.2.1",
     "lodash.castarray": "4.4.0",
     "lodash.get": "4.4.2"
   },
@@ -96,7 +96,7 @@
     "rules": {
       "complexity": [
         "warn",
-        4
+        5
       ],
       "security/detect-non-literal-fs-filename": "off",
       "security/detect-object-injection": "off",

--- a/src/core.js
+++ b/src/core.js
@@ -1,15 +1,33 @@
 import castArray from "lodash.castarray";
 import get from "lodash.get";
 
-function updateDeps(pDependencyObject, pOutdatedPackagesObject, pOptions = {}) {
-  const lSavePrefix = pOptions.saveExact ? "" : pOptions.savePrefix || "^";
+function getRangePrefix(pVersionRangeString) {
+  return (
+    // eslint-disable-next-line security/detect-unsafe-regex
+    pVersionRangeString.match(/^(?<prefix>[^0-9]{0,2}).+/).groups.prefix || ""
+  );
+}
 
+function determineSavePrefix(pVersionRangeString, pOptions) {
+  const lIndividualRangePrefix = getRangePrefix(pVersionRangeString);
+
+  if (pOptions.saveExact && lIndividualRangePrefix) {
+    return lIndividualRangePrefix;
+  }
+
+  return pOptions.saveExact ? "" : pOptions.savePrefix || "^";
+}
+
+function updateDeps(pDependencyObject, pOutdatedPackagesObject, pOptions = {}) {
   return {
     ...pDependencyObject,
     ...Object.keys(pDependencyObject)
       .filter((pDep) => Object.keys(pOutdatedPackagesObject).includes(pDep))
       .reduce((pAll, pThis) => {
-        pAll[pThis] = `${lSavePrefix}${pOutdatedPackagesObject[pThis].latest}`;
+        pAll[pThis] = `${determineSavePrefix(
+          pDependencyObject[pThis],
+          pOptions
+        )}${pOutdatedPackagesObject[pThis].latest}`;
         return pAll;
       }, {}),
   };

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -38,6 +38,17 @@ const OUTDATED_FIXTURE = {
   },
 };
 
+const DEPS_CARET_FIXTURE = {
+  "not-outdated": "1.0.0",
+  "outdated-one": "^2.0.0",
+  "outdated-possibly-pinned": "3.1.4",
+};
+const DEPS_CARET_UPDATED_LATEST_FIXTURE = {
+  "not-outdated": "1.0.0",
+  "outdated-one": "^3.0.2",
+  "outdated-possibly-pinned": "4.1.1",
+};
+
 describe("#updateDeps", () => {
   it("empty deps, no outdated yield input", () => {
     expect(up.updateDeps({}, [])).toStrictEqual({});
@@ -72,6 +83,11 @@ describe("#updateDeps", () => {
     expect(
       up.updateDeps(DEPS_FIXTURE, OUTDATED_FIXTURE, { savePrefix: "~" })
     ).toStrictEqual(DEPS_UPDATED_TILDE_FIXTURE);
+  });
+  it("deps, outdated with individual prefix, and saveExact: true, updates to latest and leaves prefix in place", () => {
+    expect(
+      up.updateDeps(DEPS_CARET_FIXTURE, OUTDATED_FIXTURE, { saveExact: true })
+    ).toStrictEqual(DEPS_CARET_UPDATED_LATEST_FIXTURE);
   });
 });
 

--- a/test/package-out-with-peer-deps-updated.json
+++ b/test/package-out-with-peer-deps-updated.json
@@ -12,7 +12,7 @@
     "dev-and-peer-dep": "4.6.0"
   },
   "peerDependencies": {
-    "dev-and-peer-dep": "4.6.0",
-    "peer-only-dep": "4.9.0"
+    "dev-and-peer-dep": ">=4.6.0",
+    "peer-only-dep": ">=4.9.0"
   }
 }


### PR DESCRIPTION
## Description

Makes it possible to override saveExact for individual dependencies. 

## Motivation and Context

If you by default pin dependencies to a specific version this is typically because you don't trust those dependencies to follow semantic versioning. However, there might be packages you _do_ want to trust e.g. because you trust the authors to do the right thing. E.g. the `semver` package is likely to follow semantic versioning to a tee. For those packages you might want to take a more relaxed approach.

This PR enables that. When your .npmrc states `saveExact = true` but  a dependency in package.json has a prefix (e.g. `"semver": "^7.0.0"`) it will retain that prefix on upgrade.

## How Has This Been Tested?

- [x] automated non-regression tests & additional automated tests
- [ ] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] :book: => will be updated in PR #21

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
