### PR TITLE
chore!: drops node 12 support

### DIFF
--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -12,15 +12,12 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 12.x
           - 14.x
           - 16.x
         platform:
           - ubuntu-latest
           - windows-latest
         exclude:
-          - node-version: 12.x
-            platform: windows-latest
           - node-version: 14.x
             platform: windows-latest
 

--- a/package.json
+++ b/package.json
@@ -54,9 +54,7 @@
   },
   "dependencies": {
     "get-stdin": "^9.0.0",
-    "libnpmconfig": "^1.2.1",
-    "lodash.castarray": "4.4.0",
-    "lodash.get": "4.4.2"
+    "libnpmconfig": "^1.2.1"
   },
   "scripts": {
     "build": "npm-run-all depcruise:graph",
@@ -72,7 +70,7 @@
     "lint:fix": "npm-run-all lint:fix:eslint lint:fix:prettier",
     "lint:fix:eslint": "eslint --fix bin src test",
     "lint:fix:prettier": "prettier --write {bin,src,test}/**/*.js *.{json,yml,md} .github",
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --collectCoverage",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --all --collectCoverage",
     "update-dependencies": "npm-run-all upem:update upem:install lint:fix check",
     "upem:update": "npm outdated --json | bin/upem.js",
     "upem:install": "npm install",
@@ -132,7 +130,7 @@
     "transform": {}
   },
   "engines": {
-    "node": "^12.20||^14.13.1||>=16"
+    "node": "^14.13.1||>=16"
   },
   "husky": {
     "hooks": {

--- a/src/core.js
+++ b/src/core.js
@@ -1,5 +1,3 @@
-import get from "lodash.get";
-
 function getRangePrefix(pVersionRangeString) {
   return (
     // eslint-disable-next-line security/detect-unsafe-regex
@@ -31,11 +29,10 @@ function updateDeps(pDependencyObject, pOutdatedPackagesObject, pOptions = {}) {
       }, {}),
   };
 }
-
 function getPinnedArray(pPackageObject) {
-  return get(pPackageObject, "upem.policies", [])
-    .filter((pPolicy) => pPolicy.policy === "pin")
-    .map((pPolicy) => get(pPolicy, "package"));
+  return (pPackageObject?.upem?.policies ?? [])
+    .filter((pPolicy) => pPolicy.policy === "pin" && Boolean(pPolicy.package))
+    .map((pPolicy) => pPolicy.package);
 }
 
 function filterOutdatedPackages(pOutdatedObject, pPackageObject) {
@@ -69,7 +66,7 @@ function updateAllDeps(pPackageObject, pOutdatedPackages = {}, pOptions = {}) {
       .filter(
         (pPackageKey) =>
           pPackageKey.includes("ependencies") &&
-          !get(pOptions, "skipDependencyTypes", []).includes(pPackageKey)
+          !(pOptions?.skipDependencyTypes ?? []).includes(pPackageKey)
       )
       .reduce((pAll, pDepKey) => {
         pAll[pDepKey] = updateDeps(

--- a/test/package-in.json
+++ b/test/package-in.json
@@ -24,7 +24,7 @@
     "pegjs": "0.10.0",
     "requirejs": "2.3.5",
     "shx": "0.3.1",
-    "ts-jest": "22.4.6",
+    "ts-jest": "^2.0.0",
     "ts-loader": "4.4.2",
     "tslint": "5.10.0",
     "typescript": "2.9.2",

--- a/test/package-out.json
+++ b/test/package-out.json
@@ -24,7 +24,7 @@
     "pegjs": "0.10.0",
     "requirejs": "2.3.5",
     "shx": "0.3.1",
-    "ts-jest": "22.4.6",
+    "ts-jest": "^2.0.0",
     "ts-loader": "4.4.2",
     "tslint": "5.10.0",
     "typescript": "2.9.2",


### PR DESCRIPTION
## Description

- See title
- 🚨 BREAKING CHANGE

## Motivation and Context

- so we can use nullish coalescing etc and drop some dependencies
- upem is only used as a devDependency - and _probably_ only by the tools listed on github's dependents tab, which use node 16 as a default environment.

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci

## Types of changes

- [x] Chore (dependency & ci housekeeping for instance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
