### PR TITLE
feature: adds support for 'wanted' update policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-security": "1.4.0",
     "eslint-plugin-unicorn": "34.0.1",
-    "husky": "4.3.8",
+    "husky": "^4.0.0",
     "jest": "27.0.6",
     "lint-staged": "^11.0.0",
     "npm-run-all": "^4.1.5",
@@ -55,6 +55,15 @@
   "dependencies": {
     "get-stdin": "^9.0.0",
     "libnpmconfig": "^1.2.1"
+  },
+  "upem": {
+    "policies": [
+      {
+        "package": "husky",
+        "policy": "wanted",
+        "because": "husky's api changed from 4 => 5 and I don't want to invest in upgrading it right now"
+      }
+    ]
   },
   "scripts": {
     "build": "npm-run-all depcruise:graph",
@@ -75,15 +84,6 @@
     "upem:update": "npm outdated --json | bin/upem.js",
     "upem:install": "npm install",
     "version": "npm-run-all build check build:stage"
-  },
-  "upem": {
-    "policies": [
-      {
-        "package": "husky",
-        "policy": "pin",
-        "because": "husky's api changed from 4 => 5 and I don't want to invest in upgrading it right now"
-      }
-    ]
   },
   "eslintConfig": {
     "extends": [

--- a/src/core-helpers.js
+++ b/src/core-helpers.js
@@ -1,0 +1,25 @@
+function getRangePrefix(pVersionRangeString) {
+  return (
+    // eslint-disable-next-line security/detect-unsafe-regex
+    pVersionRangeString.match(/^(?<prefix>[^0-9]{0,2}).+/).groups.prefix || ""
+  );
+}
+
+export function getPolicyOverrides(pPackageObject, pPolicyToFilter) {
+  return (pPackageObject?.upem?.policies ?? [])
+    .filter(
+      (pPolicy) =>
+        pPolicy.policy === pPolicyToFilter && Boolean(pPolicy.package)
+    )
+    .map((pPolicy) => pPolicy.package);
+}
+
+export function determineSavePrefix(pVersionRangeString, pOptions) {
+  const lIndividualRangePrefix = getRangePrefix(pVersionRangeString);
+
+  if (pOptions.saveExact && lIndividualRangePrefix) {
+    return lIndividualRangePrefix;
+  }
+
+  return pOptions.saveExact ? "" : pOptions.savePrefix || "^";
+}

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -48,6 +48,11 @@ const DEPS_CARET_UPDATED_LATEST_FIXTURE = {
   "outdated-one": "^3.0.2",
   "outdated-possibly-pinned": "4.1.1",
 };
+const DEPS_CARET_UPDATED_WANTED_FIXTURE = {
+  "not-outdated": "1.0.0",
+  "outdated-one": "^2.0.1",
+  "outdated-possibly-pinned": "4.1.1",
+};
 
 describe("#updateDeps", () => {
   it("empty deps, no outdated yield input", () => {
@@ -88,6 +93,13 @@ describe("#updateDeps", () => {
     expect(
       up.updateDeps(DEPS_CARET_FIXTURE, OUTDATED_FIXTURE, { saveExact: true })
     ).toStrictEqual(DEPS_CARET_UPDATED_LATEST_FIXTURE);
+  });
+  it("hoppa", () => {
+    expect(
+      up.updateDeps(DEPS_CARET_FIXTURE, OUTDATED_FIXTURE, { saveExact: true }, [
+        "outdated-one",
+      ])
+    ).toStrictEqual(DEPS_CARET_UPDATED_WANTED_FIXTURE);
   });
 });
 


### PR DESCRIPTION
## Description

- Adds support for the 'wanted' update policy in addition to the already supported 'pin' and 'latest' (which is the default)

## Motivation and Context

In some rare situations you might not want the _latest_ of a package. E.g. your dependencies' _latest_ all of a sudden is an ESM module, but you're not, so you can only use a version lower. But you still want to automatically update when there's security fixes. 

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] additional automated tests
- [x] manual test against upper's own code base

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
