### PR TITLE
refactor: replaces get-stdin with process.stdin

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "prettier": "2.7.1"
   },
   "dependencies": {
-    "get-stdin": "^9.0.0",
     "libnpmconfig": "^1.2.1"
   },
   "upem": {


### PR DESCRIPTION
## Description

- replaces `get-stdin` with `process.stdin` that ships with node by default

## Motivation and Context

Working with process.stdin is arguably a tiny bit more complicated/ less elegant than with get-stdin, but does away with a 3rd party dependency that needs to be managed (& downloaded).

## How Has This Been Tested?

- [x] green ci
- [x] additional manual testing

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
