### PR TITLE
feature: emit packages that were outdated but not updated because of policies if that's the only thing happening (and there's nothing to update)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7,39 +7,6 @@ const INDENT = 2;
 
 /**
  *
- * @param {string} pOutdatedObject
- * @param {import("../types/upem.js").IManifest} pPackageObject
- * @returns
- */
-function determineOutdated(pOutdatedObject, pPackageObject) {
-  const lOutdatedObject =
-    pOutdatedObject.length <= 0 ? {} : JSON.parse(pOutdatedObject);
-  const lPolicies = pPackageObject?.upem?.policies || [];
-  const lOutdatedList = determinePolicies(lOutdatedObject, lPolicies);
-
-  if (lOutdatedList.length <= 0) {
-    return {
-      OK: true,
-      message: "  Up'em says: Everything seems to be up to date already.\n\n",
-    };
-  }
-
-  if (lOutdatedList.filter(isUpAble).length <= 0) {
-    return {
-      OK: true,
-      message:
-        "  Up'em says: Everything not pinned in 'upem.policies' seems to be up to date already.\n\n",
-    };
-  }
-
-  return {
-    OK: true,
-    outdatedList: lOutdatedList,
-  };
-}
-
-/**
- *
  * @param {import("../types/upem.js").IUpemOutdated[]} pOutdatedList
  * @param {string} pAttribute
  */
@@ -60,23 +27,27 @@ function getMaxAttributeLength(pOutdatedList, pAttribute) {
  * @returns {string}
  */
 function constructSuccessMessage(pOutdatedList) {
+  let lReturnValue = "";
   const lMaxPackageLength = getMaxAttributeLength(pOutdatedList, "package");
   const lMaxCurrentLength = getMaxAttributeLength(pOutdatedList, "current");
   const lMaxTargetLength = getMaxAttributeLength(pOutdatedList, "target");
 
-  let lReturnValue = `Up'em just updated these outdated dependencies in package.json:${EOL}${EOL}${pOutdatedList
-    .filter(isUpAble)
-    .map(
-      (pOutdatedEntry) =>
-        `${pOutdatedEntry.package.padEnd(
-          lMaxPackageLength
-        )}${pOutdatedEntry.current.padEnd(
-          lMaxCurrentLength
-        )} -> ${pOutdatedEntry.target.padEnd(lMaxTargetLength)} (policy: ${
-          pOutdatedEntry.policy
-        })`
-    )
-    .join(EOL)}${EOL}${EOL}`;
+  const lUpdated = pOutdatedList.filter(isUpAble);
+
+  if (lUpdated.length > 0) {
+    lReturnValue += `Up'em just updated these outdated dependencies in package.json:${EOL}${EOL}${lUpdated
+      .map(
+        (pOutdatedEntry) =>
+          `${pOutdatedEntry.package.padEnd(
+            lMaxPackageLength
+          )}${pOutdatedEntry.current.padEnd(
+            lMaxCurrentLength
+          )} -> ${pOutdatedEntry.target.padEnd(lMaxTargetLength)} (policy: ${
+            pOutdatedEntry.policy
+          })`
+      )
+      .join(EOL)}${EOL}${EOL}`;
+  }
 
   const lNotUpdated = pOutdatedList.filter(
     (pOutdatedEntry) => !isUpAble(pOutdatedEntry)
@@ -95,6 +66,38 @@ function constructSuccessMessage(pOutdatedList) {
       .join(EOL)}${EOL}${EOL}`;
   }
   return lReturnValue;
+}
+
+/**
+ *
+ * @param {string} pOutdatedObject
+ * @param {import("../types/upem.js").IManifest} pPackageObject
+ * @returns
+ */
+function determineOutdated(pOutdatedObject, pPackageObject) {
+  const lOutdatedObject =
+    pOutdatedObject.length <= 0 ? {} : JSON.parse(pOutdatedObject);
+  const lPolicies = pPackageObject?.upem?.policies || [];
+  const lOutdatedList = determinePolicies(lOutdatedObject, lPolicies);
+
+  if (lOutdatedList.length <= 0) {
+    return {
+      OK: true,
+      message: "  Up'em says: Everything seems to be up to date already.\n\n",
+    };
+  }
+
+  if (lOutdatedList.filter(isUpAble).length <= 0) {
+    return {
+      OK: true,
+      message: constructSuccessMessage(lOutdatedList),
+    };
+  }
+
+  return {
+    OK: true,
+    outdatedList: lOutdatedList,
+  };
 }
 
 /**

--- a/src/main.spec.js
+++ b/src/main.spec.js
@@ -117,8 +117,9 @@ describe("main", () => {
 
     expect(lResult.OK).toBe(true);
     expect(lResult.message).toContain(
-      "Up'em says: Everything not pinned in 'upem.policies' seems to be up to date already."
+      "Up'em found these packages were outdated, but did not update them because of policies"
     );
+    expect(lResult.message).toContain("ts-jest  1.8.2   (policy: pin)");
   });
 
   it("happy day: dependencies updated with stuff in an outdated.json", () => {


### PR DESCRIPTION
## Description

- updates main.js to reflect the above

## Motivation and Context

It's also relevant when nothing was updated to know what was skipped despite being outdated.

## How Has This Been Tested?

- [x] green ci
- [x] updated unit test

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
