### PR TITLE
feature: show the dependency type when available in outdated object

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Use
 
-- Pipe `npm outdated --json` through `upem`.
+- Pipe `npm outdated --json --long` through `upem`.
 - When it's done `npm install` and re-run your automated quality checks.
 - Done.
 
@@ -21,7 +21,7 @@ and watch cat videos in the mean time:
     "lint:fix": "eslint --fix src test",
     "test": "jest",
     "upem": "npm-run-all upem:update upem:install lint:fix check",
-    "upem:update": "npm outdated --json | upem",
+    "upem:update": "npm outdated --json --long | upem",
     "upem:install": "npm install"
   }
 ```

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "lint:fix:prettier": "prettier --write \"src/**/*.js\" \"*.{json,yml,md}\" .github",
     "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --all --collectCoverage",
     "update-dependencies": "npm-run-all upem:update upem:install lint:fix check",
-    "upem:update": "npm outdated --json | src/cli.js",
+    "upem:update": "npm outdated --json --long | src/cli.js | pbcopy",
     "upem:install": "npm install",
     "version": "npm-run-all build check build:stage",
     "prepare": "husky install"

--- a/src/__mocks__/outdated-long.json
+++ b/src/__mocks__/outdated-long.json
@@ -1,0 +1,47 @@
+{
+  "@types/node": {
+    "current": "10.5.1",
+    "wanted": "10.5.1",
+    "latest": "10.5.2",
+    "dependent": "tea-time",
+    "location": "node_modules/@types/node",
+    "type": "devDependencies",
+    "homepage": "https://nodejs.org"
+  },
+  "dependency-cruiser": {
+    "current": "4.1.0",
+    "wanted": "4.1.0",
+    "latest": "4.1.1",
+    "dependent": "tea-time",
+    "location": "node_modules/dependency-cruiser",
+    "type": "devDependencies",
+    "homepage": "https://github.com/sverweij/dependency-cruiser"
+  },
+  "jest": {
+    "current": "23.2.0",
+    "wanted": "23.2.0",
+    "latest": "23.3.0",
+    "dependent": "tea-time",
+    "location": "node_modules/jest",
+    "type": "devDependencies",
+    "homepage": "https://jestjs.io"
+  },
+  "ts-jest": {
+    "current": "2.0.0",
+    "wanted": "22.4.6",
+    "latest": "23.0.0",
+    "dependent": "tea-time",
+    "location": "node_modules/ts-jest",
+    "type": "devDependencies",
+    "homepage": "https://kulshekhar.github.io/ts-jest/"
+  },
+  "webpack": {
+    "current": "4.14.0",
+    "wanted": "4.14.0",
+    "latest": "4.15.1",
+    "dependent": "tea-time",
+    "location": "node_modules/webpack",
+    "type": "dependencies",
+    "homepage": "https://webpack.js.org"
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ function getMaxAttributeLength(pOutdatedList, pAttribute) {
 
   return (
     pOutdatedList
-      .map((pOutdatedEntry) => pOutdatedEntry[pAttribute].length)
+      .map((pOutdatedEntry) => pOutdatedEntry[pAttribute]?.length ?? 0)
       .reduce((pMax, pCurrent) => (pCurrent > pMax ? pCurrent : pMax), 0) +
     lExtraPad
   );
@@ -31,6 +31,7 @@ function constructSuccessMessage(pOutdatedList) {
   const lMaxPackageLength = getMaxAttributeLength(pOutdatedList, "package");
   const lMaxCurrentLength = getMaxAttributeLength(pOutdatedList, "current");
   const lMaxTargetLength = getMaxAttributeLength(pOutdatedList, "target");
+  const lMaxTypeLength = getMaxAttributeLength(pOutdatedList, "type");
 
   const lUpdated = pOutdatedList.filter(isUpAble);
 
@@ -42,9 +43,9 @@ function constructSuccessMessage(pOutdatedList) {
             lMaxPackageLength
           )}${pOutdatedEntry.current.padEnd(
             lMaxCurrentLength
-          )} -> ${pOutdatedEntry.target.padEnd(lMaxTargetLength)} (policy: ${
-            pOutdatedEntry.policy
-          })`
+          )} -> ${pOutdatedEntry.target.padEnd(lMaxTargetLength)}${
+            pOutdatedEntry.type?.padEnd(lMaxTypeLength) ?? ""
+          } (policy: ${pOutdatedEntry.policy})`
       )
       .join(EOL)}${EOL}${EOL}`;
   }
@@ -59,9 +60,9 @@ function constructSuccessMessage(pOutdatedList) {
         (pOutdatedEntry) =>
           `${pOutdatedEntry.package.padEnd(
             lMaxPackageLength
-          )}${pOutdatedEntry.current.padEnd(lMaxTargetLength)} (policy: ${
-            pOutdatedEntry.policy
-          })`
+          )}${pOutdatedEntry.current.padEnd(lMaxTargetLength)}${
+            pOutdatedEntry.type?.padEnd(lMaxTypeLength) ?? ""
+          } (policy: ${pOutdatedEntry.policy})`
       )
       .join(EOL)}${EOL}${EOL}`;
   }

--- a/src/main.spec.js
+++ b/src/main.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { fileURLToPath } from "node:url";
 import { rmSync, chmodSync, readFileSync } from "node:fs";
 import { EOL } from "node:os";
@@ -252,6 +253,48 @@ describe("main", () => {
     );
     expect(lResult.message).toContain(
       `ts-jest             2.0.0    (policy: pin)`
+    );
+    // eslint-disable-next-line jest/max-expects
+    expect(JSON.parse(readFileSync(OUTPUT_FILENAME))).toStrictEqual(
+      JSON.parse(readFileSync(FIXTURE_FILENAME))
+    );
+  });
+
+  it("if 'type' field is available - print it", () => {
+    const INPUT_FILENAME = join(
+      __dirname,
+      "__mocks__",
+      "package-in-with-donotup-object.json"
+    );
+    const OUTPUT_FILENAME = join(__dirname, "tmp_package-out.json");
+    const FIXTURE_FILENAME = join(
+      __dirname,
+      "__fixtures__",
+      "package-out.json"
+    );
+    const lOutdated = readFileSync(
+      join(__dirname, "__mocks__", "outdated-long.json")
+    );
+
+    const lResult = upem(INPUT_FILENAME, lOutdated, OUTPUT_FILENAME, {
+      saveExact: true,
+    });
+
+    expect(lResult.OK).toBe(true);
+    expect(lResult.message).toContain(
+      "Up'em just updated these outdated dependencies in package.json"
+    );
+    expect(lResult.message).toContain(
+      `@types/node         10.5.1   -> 10.5.2  devDependencies   (policy: latest)${EOL}` +
+        `dependency-cruiser  4.1.0    -> 4.1.1   devDependencies   (policy: latest)${EOL}` +
+        `jest                23.2.0   -> 23.3.0  devDependencies   (policy: latest)${EOL}` +
+        `webpack             4.14.0   -> 4.15.1  dependencies      (policy: latest)`
+    );
+    expect(lResult.message).toContain(
+      "Up'em found these packages were outdated, but did not update them because of policies"
+    );
+    expect(lResult.message).toContain(
+      `ts-jest             2.0.0   devDependencies   (policy: pin)`
     );
     // eslint-disable-next-line jest/max-expects
     expect(JSON.parse(readFileSync(OUTPUT_FILENAME))).toStrictEqual(

--- a/types/upem.d.ts
+++ b/types/upem.d.ts
@@ -1,12 +1,15 @@
-export interface INpmOutdatedData {
+export interface INpmOutdatedRecord {
   current: string;
   wanted: string;
   latest: string;
   location: string;
+  dependent?: string;
+  type?: DependenciesTypeType;
+  homepage?: string;
 }
 
 export interface INpmOutdated {
-  [packageName: string]: INpmOutdatedData;
+  [packageName: string]: INpmOutdatedRecord;
 }
 
 export interface IMinimalManifest {
@@ -36,7 +39,7 @@ export type PolicyType =
    */
   | "current";
 
-export interface IUpemOutdated extends INpmOutdatedData {
+export interface IUpemOutdated extends INpmOutdatedRecord {
   /**
    * the name of the package the policy applies to
    */


### PR DESCRIPTION
## Description

When the (optional, for npm) 'type' field is available (`--long` switch in npm outdated) also show it in the feedback of stuffs that were upgraded.

## Motivation and Context

- useful additional information

## How Has This Been Tested?

- [x] green ci
- [x] additional/ updated unit test(s)

## Sample output

```
Up'em just updated these outdated dependencies in package.json:

eslint-plugin-jest  26.8.3   -> 26.8.4  devDependencies   (policy: latest)
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
