### PR TITLE
feature: adds --dry-run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 - When it's done `npm install` and re-run your automated quality checks.
 - Done.
 
+If you just want to see what up'em _would_ update use its `--dry-run` switch.
+
 ## Sample
 
 You can e.g. set up some npm scripts so you can `npm run upem`

--- a/src/cli.js
+++ b/src/cli.js
@@ -23,18 +23,28 @@ function emitGeneralError(pError) {
   process.exitCode = 1;
 }
 
-function executeUpdate() {
-  const lResult = upem(MANIFEST, gBuffer, MANIFEST, UPEM_OPTIONS);
+/**
+ *
+ * @param {string[]} pArguments
+ */
+function executeUpdate(pArguments) {
+  let lUpemOptions = {
+    ...UPEM_OPTIONS,
+    dryRun: pArguments[pArguments.length - 1] === "--dry-run",
+  };
+  return () => {
+    const lResult = upem(MANIFEST, gBuffer, MANIFEST, lUpemOptions);
 
-  if (lResult.OK) {
-    process.stdout.write(lResult.message);
-  } else {
-    process.stderr.write(lResult.message);
-    process.exitCode = 1;
-  }
+    if (lResult.OK) {
+      process.stdout.write(lResult.message);
+    } else {
+      process.stderr.write(lResult.message);
+      process.exitCode = 1;
+    }
+  };
 }
 
 process.stdin
   .on("data", bufferChunk)
-  .on("end", executeUpdate)
+  .on("end", executeUpdate(process.argv))
   .on("error", emitGeneralError);

--- a/src/main.js
+++ b/src/main.js
@@ -125,19 +125,21 @@ export default function upem(
     }
 
     try {
-      writeFileSync(
-        pPackageOutputFileName,
-        JSON.stringify(
-          updateManifest(
-            lPackageObject,
-            lOutdatedResult.outdatedList.filter(isUpAble),
-            pOptions
-          ),
-          // eslint-disable-next-line unicorn/no-null
-          null,
-          INDENT
-        )
-      );
+      if (!pOptions.dryRun) {
+        writeFileSync(
+          pPackageOutputFileName,
+          JSON.stringify(
+            updateManifest(
+              lPackageObject,
+              lOutdatedResult.outdatedList.filter(isUpAble),
+              pOptions
+            ),
+            // eslint-disable-next-line unicorn/no-null
+            null,
+            INDENT
+          )
+        );
+      }
       return {
         OK: true,
         message: constructSuccessMessage(lOutdatedResult.outdatedList),

--- a/src/main.spec.js
+++ b/src/main.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import { fileURLToPath } from "node:url";
-import { rmSync, chmodSync, readFileSync } from "node:fs";
+import { rmSync, chmodSync, readFileSync, existsSync } from "node:fs";
 import { EOL } from "node:os";
 import { join } from "node:path";
 import upem from "./main.js";
@@ -300,5 +300,22 @@ describe("main", () => {
     expect(JSON.parse(readFileSync(OUTPUT_FILENAME))).toStrictEqual(
       JSON.parse(readFileSync(FIXTURE_FILENAME))
     );
+  });
+
+  it("doesn't update the specified manifest when dryRun is specified and true", () => {
+    const INPUT_FILENAME = join(
+      __dirname,
+      "__mocks__",
+      "package-in-with-donotup-object.json"
+    );
+    const OUTPUT_FILENAME = join(
+      __dirname,
+      "tmp_this-file-should-not-be-created.json"
+    );
+    const lOutdated = readFileSync(
+      join(__dirname, "__mocks__", "outdated.json")
+    );
+    upem(INPUT_FILENAME, lOutdated, OUTPUT_FILENAME, { dryRun: true });
+    expect(existsSync(OUTPUT_FILENAME)).toBe(false);
   });
 });

--- a/types/upem.d.ts
+++ b/types/upem.d.ts
@@ -93,6 +93,11 @@ export interface IUpemOptions {
    * sense for peerDependencies, that usually have large ranges in any case
    */
   skipDependencyTypes?: DependenciesTypeType[];
+  /**
+   * if true upem will not update the manifest, but just output what it would've done
+   * in all other cases will also update the manifest
+   */
+  dryRun: boolean;
 }
 
 export interface IUpemReturn {


### PR DESCRIPTION
## Description

- adds --dry-run command line option that dry-runs the up'em command

## Motivation and Context

- seems useful 

## How Has This Been Tested?

- [x] green ci
- [x] additional unit test

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
