### PR TITLE
chore(test): migrates from jest to mocha

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,7 +26,7 @@ To make this as easy as possible for you, here's some simple guidelines:
 - Code quality
   - Additions pass eslint (as configured in this repo -
     `npm run lint:fix` will help you loads).
-  - Unit tests (we use jest) prove your code does what it intends.
+  - Unit tests (we use mocha) prove your code does what it intends.
   - Your code does not introduce regressions - `npm run check` proves this.
   - Code style (you know, petty things like indentations, where brackets go,
     how variables & parameters are named) fits in with the current code base.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
       - main
   pull_request:
 
+env:
+  CI: true
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   check:
     strategy:
@@ -24,38 +31,12 @@ jobs:
     runs-on: ${{matrix.platform}}
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v1
-      - name: set up node ${{matrix.node-version}}@${{matrix.platform}}
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node-version}}
-      - name: install
-        run: |
-          node --version
-          npm install
-        shell: bash
-        env:
-          CI: true
-      - name: lint (run on one platform only)
-        run: |
-          node --version
-          npm run lint
+      - run: npm install
+      - run: npm run lint
         if: matrix.platform == 'ubuntu-latest' && matrix.node-version == '18.x'
-        shell: bash
-        env:
-          CI: true
-      - name: forbidden dependency check
-        run: |
-          node --version
-          npm run depcruise
-        shell: bash
-        env:
-          CI: true
-      - name: test coverage
-        run: |
-          node --version
-          NODE_OPTIONS=--experimental-vm-modules npx jest --collectCoverage
-        shell: bash
-        env:
-          CI: true
+      - run: npm run depcruise
+      - run: npm test

--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  extension: ["js"],
+  spec: "src/**/*.spec.js",
+};

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ and watch cat videos in the mean time:
     "lint": "eslint src test",
     "lint:archi": "depcruise --validate -- src test",
     "lint:fix": "eslint --fix src test",
-    "test": "jest",
+    "test": "mocha",
     "upem": "npm-run-all upem:update upem:install lint:fix check",
     "upem:update": "npm outdated --json --long | upem",
     "upem:install": "npm install"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "url": "https://github.com/sverweij/upem/issues"
   },
   "devDependencies": {
+    "c8": "7.12.0",
     "dependency-cruiser": "11.15.0",
     "eslint": "8.23.0",
     "eslint-config-moving-meadow": "4.0.1",
@@ -43,13 +44,13 @@
     "eslint-plugin-budapestian": "5.0.0",
     "eslint-plugin-eslint-comments": "3.2.0",
     "eslint-plugin-import": "2.26.0",
-    "eslint-plugin-jest": "27.0.1",
+    "eslint-plugin-mocha": "10.1.0",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-security": "1.5.0",
     "eslint-plugin-unicorn": "43.0.2",
     "husky": "8.0.1",
-    "jest": "29.0.1",
     "lint-staged": "13.0.3",
+    "mocha": "10.0.0",
     "npm-run-all": "4.1.5",
     "prettier": "2.7.1"
   },
@@ -64,13 +65,13 @@
     "depcruise:graph": "npm-run-all depcruise:graph:html",
     "depcruise:graph:html": "depcruise src --validate --cache --output-type dot | dot -T svg | tee docs/dependencygraph.svg | depcruise-wrap-stream-in-html > docs/dependencygraph.html",
     "depcruise:graph:view": "depcruise src --validate --cache --output-type dot --prefix vscode://file/$(pwd)/ | dot -T svg | depcruise-wrap-stream-in-html | browser",
-    "lint": "npm-run-all lint:eslint lint:prettier",
+    "format": "prettier --write \"src/**/*.js\" \"*.{json,yml,md}\" .github",
+    "format:check": "prettier --check \"src/**/*.js\" \"*.{json,yml,md}\" .github",
+    "lint": "npm-run-all lint:eslint format:check",
     "lint:eslint": "eslint src",
-    "lint:prettier": "prettier --check \"src/**/*.js\" \"*.{json,yml,md}\" .github",
-    "lint:fix": "npm-run-all lint:fix:eslint lint:fix:prettier",
+    "lint:fix": "npm-run-all lint:fix:eslint format",
     "lint:fix:eslint": "eslint --fix src",
-    "lint:fix:prettier": "prettier --write \"src/**/*.js\" \"*.{json,yml,md}\" .github",
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --all --collectCoverage",
+    "test": "c8 --check-coverage --statements 100 --branches 100 --functions 100 --lines 100 --exclude \"{src/**/*.spec.js,src/__mocks__/*,src/__fixtures__/*,.mocharc.cjs}\" --reporter text-summary --reporter html --reporter json-summary mocha",
     "update-dependencies": "npm-run-all upem:update upem:install lint:fix check",
     "upem-outdated": "npm outdated --json --long | src/cli.js --dry-run",
     "upem:update": "npm outdated --json --long | src/cli.js | pbcopy && pbpaste",
@@ -95,7 +96,6 @@
       "node/no-unsupported-features/es-syntax": "off",
       "sort-imports": "off",
       "import/no-relative-parent-imports": "off",
-      "jest/require-hook": "off",
       "unicorn/prefer-at": "off"
     },
     "overrides": [
@@ -104,7 +104,7 @@
           "src/**/*.spec.js"
         ],
         "env": {
-          "jest": true
+          "mocha": true
         },
         "rules": {
           "node/global-require": "off",
@@ -112,17 +112,6 @@
         }
       }
     ]
-  },
-  "jest": {
-    "clearMocks": true,
-    "coverageDirectory": "coverage",
-    "coverageReporters": [
-      "text-summary",
-      "lcov",
-      "html"
-    ],
-    "testEnvironment": "node",
-    "transform": {}
   },
   "engines": {
     "node": "^14.13.1||>=16"

--- a/src/determine-policies.spec.js
+++ b/src/determine-policies.spec.js
@@ -1,8 +1,9 @@
+import { deepStrictEqual } from "node:assert";
 import { determinePolicies } from "./determine-policies.js";
 
 describe("determinePolicies", () => {
   it("when there's no outdated there's an empty array of policies", () => {
-    expect(determinePolicies({}, [])).toStrictEqual([]);
+    deepStrictEqual(determinePolicies({}, []), []);
   });
 
   it("adds policy related attributes & transforms it into an array", () => {
@@ -14,7 +15,7 @@ describe("determinePolicies", () => {
         location: "node_modules/@types/node",
       },
     };
-    expect(determinePolicies(lSomeOutdated, [])).toStrictEqual([
+    deepStrictEqual(determinePolicies(lSomeOutdated, []), [
       {
         current: "10.5.1",
         wanted: "10.5.1",

--- a/src/update-manifest.js
+++ b/src/update-manifest.js
@@ -16,7 +16,10 @@ function getUpAbleDependencyKeys(pSkipDependencyTypes) {
  */
 function getRangePrefix(pVersionRangeString) {
   return (
+    /* c8 ignore start */
+    /* c8 ignore - as the ?? "" safety valve is never hit */
     pVersionRangeString.match(/^(?<prefix>[^0-9]{0,2}).+/)?.groups?.prefix ?? ""
+    /* c8 ignore stop */
   );
 }
 

--- a/src/update-manifest.spec.js
+++ b/src/update-manifest.spec.js
@@ -1,3 +1,4 @@
+import { strictEqual, deepStrictEqual } from "node:assert";
 import { updateDependencyKey, determineSavePrefix } from "./update-manifest.js";
 import { determinePolicies } from "./determine-policies.js";
 
@@ -58,82 +59,90 @@ const DEPS_CARET_UPDATED_WANTED_FIXTURE = {
 
 describe("updateManifest - updateDependencyKey", () => {
   it("empty deps, no outdated yield input", () => {
-    expect(updateDependencyKey({}, [])).toStrictEqual({});
+    deepStrictEqual(updateDependencyKey({}, []), {});
   });
   it("deps, no outdated yield input", () => {
-    expect(updateDependencyKey(DEPS_FIXTURE, [])).toStrictEqual(DEPS_FIXTURE);
+    deepStrictEqual(updateDependencyKey(DEPS_FIXTURE, []), DEPS_FIXTURE);
   });
   it("deps, outdated yields updated deps, prefixed with carets", () => {
-    expect(
-      updateDependencyKey(DEPS_FIXTURE, OUTDATED_NO_POLICIES_FIXTURE)
-    ).toStrictEqual(DEPS_UPDATED_CARET_FIXTURE);
+    deepStrictEqual(
+      updateDependencyKey(DEPS_FIXTURE, OUTDATED_NO_POLICIES_FIXTURE),
+      DEPS_UPDATED_CARET_FIXTURE
+    );
   });
   it("deps, outdated with saveExact yields updated deps, pinned", () => {
-    expect(
+    deepStrictEqual(
       updateDependencyKey(DEPS_FIXTURE, OUTDATED_NO_POLICIES_FIXTURE, {
         saveExact: true,
-      })
-    ).toStrictEqual(DEPS_UPDATED_PINNED_FIXTURE);
+      }),
+      DEPS_UPDATED_PINNED_FIXTURE
+    );
   });
   it("deps, outdated with saveExact yields updated deps, pinned even when savePrefix ^ is provided", () => {
-    expect(
+    deepStrictEqual(
       updateDependencyKey(DEPS_FIXTURE, OUTDATED_NO_POLICIES_FIXTURE, {
         saveExact: true,
         savePrefix: "^",
-      })
-    ).toStrictEqual(DEPS_UPDATED_PINNED_FIXTURE);
+      }),
+      DEPS_UPDATED_PINNED_FIXTURE
+    );
   });
   it("deps, outdated with saveExact false yields updated deps, caret prefixed", () => {
-    expect(
+    deepStrictEqual(
       updateDependencyKey(DEPS_FIXTURE, OUTDATED_NO_POLICIES_FIXTURE, {
         saveExact: false,
-      })
-    ).toStrictEqual(DEPS_UPDATED_CARET_FIXTURE);
+      }),
+      DEPS_UPDATED_CARET_FIXTURE
+    );
   });
   it("deps, outdated with savePrefix ~ yields updated deps, tilde prefixed", () => {
-    expect(
+    deepStrictEqual(
       updateDependencyKey(DEPS_FIXTURE, OUTDATED_NO_POLICIES_FIXTURE, {
         savePrefix: "~",
-      })
-    ).toStrictEqual(DEPS_UPDATED_TILDE_FIXTURE);
+      }),
+      DEPS_UPDATED_TILDE_FIXTURE
+    );
   });
   it("deps, outdated with individual prefix, and saveExact: true, updates to latest and leaves prefix in place", () => {
-    expect(
+    deepStrictEqual(
       updateDependencyKey(DEPS_CARET_FIXTURE, OUTDATED_NO_POLICIES_FIXTURE, {
         saveExact: true,
-      })
-    ).toStrictEqual(DEPS_CARET_UPDATED_LATEST_FIXTURE);
+      }),
+      DEPS_CARET_UPDATED_LATEST_FIXTURE
+    );
   });
   it("updates those with a 'wanted' policy to wanted", () => {
-    expect(
+    deepStrictEqual(
       updateDependencyKey(
         DEPS_CARET_FIXTURE,
         OUTDATED_WANTED_POLICIES_FIXTURE,
         { saveExact: true }
-      )
-    ).toStrictEqual(DEPS_CARET_UPDATED_WANTED_FIXTURE);
+      ),
+      DEPS_CARET_UPDATED_WANTED_FIXTURE
+    );
   });
 });
 
 describe("updateManifest - determineSavePrefix", () => {
   it("without options, regardless, returns ^ (no prefix case)", () => {
-    expect(determineSavePrefix("0.0.0")).toBe("^");
+    strictEqual(determineSavePrefix("0.0.0"), "^");
   });
   it("without options, regardless, returns ^ (>= case)", () => {
-    expect(determineSavePrefix(">=0.0.0")).toBe("^");
+    strictEqual(determineSavePrefix(">=0.0.0"), "^");
   });
   it("with only saveExact = false, returns ^ as a prefix", () => {
-    expect(determineSavePrefix(">=0.0.0", { saveExact: false })).toBe("^");
+    strictEqual(determineSavePrefix(">=0.0.0", { saveExact: false }), "^");
   });
   it("with saveExact = false and a savePrefix, returns that savePrefix", () => {
-    expect(
-      determineSavePrefix(">=0.0.0", { saveExact: false, savePrefix: "~" })
-    ).toBe("~");
+    strictEqual(
+      determineSavePrefix(">=0.0.0", { saveExact: false, savePrefix: "~" }),
+      "~"
+    );
   });
   it("with only saveExact = true, and an individual prefix returns that prefix", () => {
-    expect(determineSavePrefix(">=0.0.0", { saveExact: true })).toBe(">=");
+    strictEqual(determineSavePrefix(">=0.0.0", { saveExact: true }), ">=");
   });
   it("with only saveExact = true, and no individual prefix returns empty string", () => {
-    expect(determineSavePrefix("0.0.0", { saveExact: true })).toBe("");
+    strictEqual(determineSavePrefix("0.0.0", { saveExact: true }), "");
   });
 });


### PR DESCRIPTION
## Description, Motivation and Context

- migrates from jest to mocha + c8 + node:assert (to keep up with the times)
- 🏕️ cleans up the ci workflow

## How Has This Been Tested?

- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
