### PR TITLE
refactor: moves types as close to where they define the interfaces as possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "bin": {
     "upem": "dist/cli.js"
   },
-  "exports": {
-    ".": "./dist/main.js"
-  },
   "files": [
     "dist",
     "package.json",
@@ -75,9 +72,9 @@
     "format": "prettier --write \"src/**/*.{ts,js}\" \"*.{json,yml,md}\" .github",
     "format:check": "prettier --check \"src/**/*.{ts,js}\" \"*.{json,yml,md}\" .github",
     "lint": "npm-run-all lint:eslint format:check",
-    "lint:eslint": "eslint src types",
+    "lint:eslint": "eslint src",
     "lint:fix": "npm-run-all lint:fix:eslint format",
-    "lint:fix:eslint": "eslint --fix src types",
+    "lint:fix:eslint": "eslint --fix src",
     "test": "c8 node --no-warnings --loader 'tsx' --test-reporter dot --test src/*.test.ts",
     "test:watch": "find src | NODE_OPTIONS=--no-warnings entr -c npm test",
     "update-dependencies": "npm-run-all upem:update upem:install lint:fix check",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 import { join } from "node:path";
 // @ts-expect-error - no type definition exists for libnpmconfig
 import libNpmConfig from "libnpmconfig";
-import type { IUpemOptions } from "../types/upem.js";
+import type { IUpemOptions } from "./types.js";
 import upem from "./main.js";
 
 const MANIFEST = join(process.cwd(), "package.json");

--- a/src/determine-policies.ts
+++ b/src/determine-policies.ts
@@ -3,7 +3,7 @@ import type {
   IFlatNpmOutdated,
   IUpemOutdated,
   IUpemPolicy,
-} from "types/upem.js";
+} from "./types.js";
 
 function determineTargetVersion(
   pOutdatedEntry: IFlatNpmOutdated,

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import {
   IUpemOptions,
   IUpemOutdated,
   IUpemReturn,
-} from "types/upem.js";
+} from "./types.js";
 import { determinePolicies, isUpAble } from "./determine-policies.js";
 import { updateManifest } from "./update-manifest.js";
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -36,7 +36,7 @@ export interface INpmOutdatedRecord {
 }
 
 export interface INpmOutdated {
-  [package: string]: INpmOutdatedRecord;
+  [packageName: string]: INpmOutdatedRecord;
 }
 
 export interface IFlatNpmOutdated extends INpmOutdatedRecord {

--- a/src/update-manifest.ts
+++ b/src/update-manifest.ts
@@ -3,7 +3,7 @@ import type {
   IManifest,
   IUpemOptions,
   IUpemOutdated,
-} from "types/upem.js";
+} from "./types.js";
 
 function isUpAbleDependencyKey(pSkipDependencyTypes: DependenciesTypeType[]) {
   return (pManifestKey: string): boolean =>


### PR DESCRIPTION
## Description

- moves `types` to `src`
- removes exports & main stuff from package.json

## Motivation and Context

more straightforward to maintain; also the exports stuff is not needed as this module is meant to be used as a cli tool only.

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
